### PR TITLE
Rename Sparsity to Occupancy

### DIFF
--- a/hgcal_metrics.py
+++ b/hgcal_metrics.py
@@ -182,7 +182,7 @@ def get_feat_names(nLayers):
     for i in range(nLayers): feat_names.append("X Width Layer %i" % i)
     for i in range(nLayers): feat_names.append("Y Center Layer %i" % i)
     for i in range(nLayers): feat_names.append("Y Width Layer %i" % i)
-    for i in range(nLayers): feat_names.append("Sparsity Layer %i" % i)
+    for i in range(nLayers): feat_names.append("Occupancy Layer %i" % i)
 
     return feat_names
 
@@ -216,9 +216,9 @@ def compute_feats(showers, incident_E, geom):
 
 
     layer_voxels = np.reshape(showers,(showers.shape[0],showers.shape[1],-1))
-    layer_sparsity = np.sum(layer_voxels > eps, axis = -1) / layer_voxels.shape[2]
+    layer_occupancy = np.sum(layer_voxels > eps, axis = -1)
 
-    feats = np.concatenate([incident_E, E_ratio, E_per_layer, E_x_center, E_x_width, E_y_center, E_y_width, layer_sparsity], axis = -1).astype(np.float32)
+    feats = np.concatenate([incident_E, E_ratio, E_per_layer, E_x_center, E_x_width, E_y_center, E_y_width, layer_occupancy], axis = -1).astype(np.float32)
 
     return feats
 
@@ -258,7 +258,7 @@ def compute_metrics(flags):
 
     print("Data shape", shape_plot)
 
-    if(not os.path.exists(flags.plot_folder)): os.system("mkdir -p %s" % flags.plot_folder)
+    if(not os.path.exists(flags.plot_folder)): os.makedirs(flags.plot_folder, exist_ok=True)
 
 
     geom_conv = None
@@ -352,12 +352,12 @@ def compute_metrics(flags):
     nLayers = shape_plot[1]
     feat_names = get_feat_names(nLayers)
 
-    if(flags.no_sparse):
-        #don't include sparsity feature
-        feats_no_sparse = [idx for idx,feat_name in enumerate(feat_names) if 'Sparsity' not in feat_name] 
-        feats_geant = feats_geant[:, feats_no_sparse]
-        feats_gen = feats_gen[:, feats_no_sparse]
-        feat_names = [feat_names[idx] for idx in feats_no_sparse]
+    if(flags.no_occupancy):
+        #don't include occupancy feature
+        feats_no_occupancy = [idx for idx,feat_name in enumerate(feat_names) if 'Occupancy' not in feat_name] 
+        feats_geant = feats_geant[:, feats_no_occupancy]
+        feats_gen = feats_gen[:, feats_no_occupancy]
+        feat_names = [feat_names[idx] for idx in feats_no_occupancy]
 
 
 
@@ -383,11 +383,12 @@ def compute_metrics(flags):
                 "Energy": 0.,
                 "Center": 0.,
                 "Width": 0.,
-                "Sparsity": 0., 
+                "Occupancy": 0., 
                 "all": 0., 
                 }
         for i,feat_name in enumerate(feat_names):
-            if(flags.plot): fname = flags.plot_folder + feat_names[i].replace(" ", "")
+            if flags.plot:
+                fname = os.path.join(flags.plot_folder, feat_names[i].replace(" ", ""))
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 sep_power = make_hist(feats_geant[:,i], feats_gen[:,i], xlabel = feat_name, model_name=flags.name, fname=fname)
@@ -403,8 +404,8 @@ def compute_metrics(flags):
                 sum_key = "Center"
             elif("Width" in feat_name):
                 sum_key = "Width"
-            elif("Sparsity" in feat_name):
-                sum_key = "Sparsity"
+            elif("Occupancy" in feat_name):
+                sum_key = "Occupancy"
             else:
                 print("unmatched feat %s" % feat_name)
 
@@ -532,7 +533,7 @@ if(__name__ == "__main__"):
 
     parser.add_argument('--geant_only', action='store_true', default=False,help='Plots with just geant')
     parser.add_argument('--reprocess', action='store_true', default=False,help='Recompute features for eval')
-    parser.add_argument('--no_sparse', action='store_true', default=False,help='Dont include sparsity feature')
+    parser.add_argument('--no_occupancy', action='store_true', default=False,help='Dont include occupancy feature')
     parser.add_argument('-m', '--mode', default='all', help='Which eval metrics to run. Options : hist, cls, fpd, all (default)')
 
     flags = parser.parse_args()

--- a/plotting/plotting_utils.py
+++ b/plotting/plotting_utils.py
@@ -21,16 +21,20 @@ def make_hist(
     logy=False,
     binning=None,
     label_loc="best",
-    normalize=True,
     model_name="Model",
     fname="",
     leg_font=16,
 ):
 
     if binning is None:
-        binning = np.linspace(
-            np.quantile(reference, 0.0), np.quantile(reference, 1), 50
-        )
+        lower_bound = np.quantile(reference, 0.0) - 1e-8
+        upper_bound = np.quantile(reference, 1.0) + 1e-8
+        if "occupancy" in xlabel.lower():
+            # avoid binning effects for discrete features
+            delta = np.ceil((upper_bound - lower_bound) / 50)
+            binning = np.arange(lower_bound, upper_bound + 1.0, delta)
+        else:
+            binning = np.linspace(lower_bound, upper_bound, 50)
 
     fig, ax = plt.subplots(
         2,


### PR DESCRIPTION
**rename sparsity to occupancy:**
When more cells are active, this quantity increases. This is better reflected by the term "occupancy". You would expect the number of active cells to decrease when a quantity called "sparsity" increases.

**remove division by `layer_voxels.shape[2]`:**
`layer_voxels.shape[2]` is not a meaningful quantity. It depended on the size of the simulation volume we selected and the amount of zero padding we used when storing the data. Therefore, it should not enter into any observable we use.

**remove binning effect:**
In the sparsity/occupancy plots, clear binning effects were visible, originating from the fact that this quantity is discrete. By ensuring the bin size is a multiple of one, this binning effect can be removed.

**using Python build-ins:**
Using `os.makedirs([...])` rather then `os.system("mkdir -p [...])`. Using `os.path.join` rather than string concatenation.